### PR TITLE
feat: added workflow that sets up a preview environment

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -13,7 +13,7 @@ env:
   DOMAIN_NAME: ${{ secrets.DOMAIN_NAME }}
   NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
   NEON_PROJECT: ${{ secrets.NEON_PROJECT }}
-  STAGE: ${{ github.event.number || github.sha }}
+  STAGE: ${{ github.event.number && 'pr-' || '' }}${{ github.event.number || github.sha }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -97,6 +97,8 @@ jobs:
   deploy-engine:
     runs-on: ubuntu-latest
     needs: [build, tests, create-database-branch]
+    env:
+      DATABASE_URL: ${{ env.DATABASE_URL }}
 
     steps:
       - uses: actions/checkout@v4
@@ -133,6 +135,8 @@ jobs:
   deploy-endpoints:
     runs-on: ubuntu-latest
     needs: [build, tests, deploy-engine, create-database-branch]
+    env:
+      DATABASE_URL: ${{ env.DATABASE_URL }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -80,63 +80,56 @@ jobs:
 
       - run: pnpm test
 
-  create-database-branch:
+  deploy-engine:
     runs-on: ubuntu-latest
     needs: [build, tests]
 
     steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: '${{ runner.os }}-turbo-${{ github.sha }}'
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/atlas-deploy-role
+          aws-region: eu-west-1
+
       - uses: neondatabase/create-branch-action@v6
         id: create-branch
         with:
           project_id: ${{ secrets.NEON_PROJECT }}
           api_key: ${{ secrets.NEON_API_KEY }}
           branch_name: ${{ github.event.number || github.sha }}
-      - run: psql ${{ steps.create-branch.outputs.db_url_pooled }} -c "SELECT * FROM NOW();"
-      - run: echo "DATABASE_URL=${{ steps.create-branch.outputs.db_url_pooled }}" >> $GITHUB_ENV
-
-  deploy-engine:
-    runs-on: ubuntu-latest
-    needs: [build, tests, create-database-branch]
-    env:
-      DATABASE_URL: ${{ env.DATABASE_URL }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
-      - uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: '${{ runner.os }}-turbo-${{ github.sha }}'
-          restore-keys: |
-            ${{ runner.os }}-turbo-
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
-
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/atlas-deploy-role
-          aws-region: eu-west-1
 
       - run: pnpm cdk:network -- deploy --all --require-approval never --context stage=${{ env.STAGE }}
 
       - run: pnpm cdk:migrations -- deploy --all --require-approval never --context stage=${{ env.STAGE }}
+        env:
+          DATABASE_URL: ${{ steps.create-branch.outputs.db_url_pooled }}
 
       - run: pnpm cdk:engine -- deploy --all --require-approval never --context stage=${{ env.STAGE }}
+        env:
+          DATABASE_URL: ${{ steps.create-branch.outputs.db_url_pooled }}
 
   deploy-endpoints:
     runs-on: ubuntu-latest
-    needs: [build, tests, deploy-engine, create-database-branch]
-    env:
-      DATABASE_URL: ${{ env.DATABASE_URL }}
+    needs: [build, tests, deploy-engine]
 
     steps:
       - uses: actions/checkout@v4
@@ -164,13 +157,24 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/atlas-deploy-role
           aws-region: eu-west-1
 
+      - uses: neondatabase/create-branch-action@v6
+        id: create-branch
+        with:
+          project_id: ${{ secrets.NEON_PROJECT }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+          branch_name: ${{ github.event.number || github.sha }}
+
       - run: pnpm cdk:backend-api -- deploy --all --require-approval never --context stage=${{ env.STAGE }}
+        env:
+          DATABASE_URL: ${{ steps.create-branch.outputs.db_url_pooled }}
 
       - run: pnpm cdk:frontend-api -- deploy --all --require-approval never --context stage=${{ env.STAGE }}
+        env:
+          DATABASE_URL: ${{ steps.create-branch.outputs.db_url_pooled }}
 
 #  deploy-app:
 #    runs-on: ubuntu-latest
-#    needs: [build, tests, deploy-engine, create-database-branch]
+#    needs: [build, tests, deploy-engine]
 #    environment: preview
 #
 #    steps:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,196 @@
+name: Preview Deployment
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+
+env:
+  CI: true
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+  TURBO_TEAM: ${{ secrets.VERCEL_ORG_ID }}
+  DOMAIN_NAME: ${{ secrets.DOMAIN_NAME }}
+  NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+  NEON_PROJECT: ${{ secrets.NEON_PROJECT }}
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: '${{ github.workflow }}-${{ github.event.number || github.sha }}'
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: '${{ runner.os }}-turbo-${{ github.sha }}'
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build
+
+  tests:
+    runs-on: ubuntu-latest
+    needs: [build]
+    concurrency:
+      group: '${{ github.workflow }}-${{ github.event.number || github.sha }}'
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: '${{ runner.os }}-turbo-${{ github.sha }}'
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm test
+
+  create-database-branch:
+    runs-on: ubuntu-latest
+    needs: [build, tests]
+
+    steps:
+      - uses: neondatabase/create-branch-action@v6
+        id: create-branch
+        with:
+          project_id: ${{ secrets.NEON_PROJECT }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+          branch_name: ${{ github.event.number || github.sha }}
+      - run: psql ${{ steps.create-branch.outputs.db_url_pooled }} -c "SELECT * FROM NOW();"
+      - run: echo "DATABASE_URL=${{ steps.create-branch.outputs.db_url_pooled }}" >> $GITHUB_ENV
+
+  deploy-engine:
+    runs-on: ubuntu-latest
+    needs: [build, tests, create-database-branch]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: '${{ runner.os }}-turbo-${{ github.sha }}'
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/atlas-deploy-role
+          aws-region: eu-west-1
+
+      - run: pnpm cdk:network -- deploy --all --require-approval never
+
+      - run: pnpm cdk:migrations -- deploy --all --require-approval never
+
+      - run: pnpm cdk:engine -- deploy --all --require-approval never
+
+  deploy-endpoints:
+    runs-on: ubuntu-latest
+    needs: [build, tests, deploy-engine, create-database-branch]
+    env:
+      STAGE: ${{ github.event.number || github.sha }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: '${{ runner.os }}-turbo-${{ github.sha }}'
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/atlas-deploy-role
+          aws-region: eu-west-1
+
+      - run: pnpm cdk:backend-api -- deploy --all --require-approval never
+
+      - run: pnpm cdk:frontend-api -- deploy --all --require-approval never
+
+  deploy-app:
+    runs-on: ubuntu-latest
+    needs: [build, tests, deploy-engine, create-database-branch]
+    environment: preview
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: '${{ runner.os }}-turbo-${{ github.sha }}'
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm vercel deploy --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -165,6 +165,8 @@ jobs:
           branch_name: ${{ github.event.number || github.sha }}
 
       - run: pnpm cdk:api -- deploy --all --require-approval never --context stage=${{ env.STAGE }}
+        env:
+          DATABASE_URL: ${{ steps.create-branch.outputs.db_url_pooled }}
 
 #  deploy-app:
 #    runs-on: ubuntu-latest

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -13,6 +13,7 @@ env:
   DOMAIN_NAME: ${{ secrets.DOMAIN_NAME }}
   NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
   NEON_PROJECT: ${{ secrets.NEON_PROJECT }}
+  STAGE: ${{ github.event.number || github.sha }}
 
 on:
   workflow_dispatch:
@@ -123,17 +124,15 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/atlas-deploy-role
           aws-region: eu-west-1
 
-      - run: pnpm cdk:network -- deploy --all --require-approval never
+      - run: pnpm cdk:network -- deploy --all --require-approval never --context stage=${{ env.STAGE }}
 
-      - run: pnpm cdk:migrations -- deploy --all --require-approval never
+      - run: pnpm cdk:migrations -- deploy --all --require-approval never --context stage=${{ env.STAGE }}
 
-      - run: pnpm cdk:engine -- deploy --all --require-approval never
+      - run: pnpm cdk:engine -- deploy --all --require-approval never --context stage=${{ env.STAGE }}
 
   deploy-endpoints:
     runs-on: ubuntu-latest
     needs: [build, tests, deploy-engine, create-database-branch]
-    env:
-      STAGE: ${{ github.event.number || github.sha }}
 
     steps:
       - uses: actions/checkout@v4
@@ -161,9 +160,9 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/atlas-deploy-role
           aws-region: eu-west-1
 
-      - run: pnpm cdk:backend-api -- deploy --all --require-approval never
+      - run: pnpm cdk:backend-api -- deploy --all --require-approval never --context stage=${{ env.STAGE }}
 
-      - run: pnpm cdk:frontend-api -- deploy --all --require-approval never
+      - run: pnpm cdk:frontend-api -- deploy --all --require-approval never --context stage=${{ env.STAGE }}
 
 #  deploy-app:
 #    runs-on: ubuntu-latest

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -164,13 +164,7 @@ jobs:
           api_key: ${{ secrets.NEON_API_KEY }}
           branch_name: ${{ github.event.number || github.sha }}
 
-      - run: pnpm cdk:backend-api -- deploy --all --require-approval never --context stage=${{ env.STAGE }}
-        env:
-          DATABASE_URL: ${{ steps.create-branch.outputs.db_url_pooled }}
-
-      - run: pnpm cdk:frontend-api -- deploy --all --require-approval never --context stage=${{ env.STAGE }}
-        env:
-          DATABASE_URL: ${{ steps.create-branch.outputs.db_url_pooled }}
+      - run: pnpm cdk:api -- deploy --all --require-approval never --context stage=${{ env.STAGE }}
 
 #  deploy-app:
 #    runs-on: ubuntu-latest

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -165,32 +165,32 @@ jobs:
 
       - run: pnpm cdk:frontend-api -- deploy --all --require-approval never
 
-  deploy-app:
-    runs-on: ubuntu-latest
-    needs: [build, tests, deploy-engine, create-database-branch]
-    environment: preview
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
-      - uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: '${{ runner.os }}-turbo-${{ github.sha }}'
-          restore-keys: |
-            ${{ runner.os }}-turbo-
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
-
-      - run: pnpm vercel deploy --token=${{ secrets.VERCEL_TOKEN }}
-        env:
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+#  deploy-app:
+#    runs-on: ubuntu-latest
+#    needs: [build, tests, deploy-engine, create-database-branch]
+#    environment: preview
+#
+#    steps:
+#      - uses: actions/checkout@v4
+#
+#      - uses: pnpm/action-setup@v4
+#        with:
+#          run_install: false
+#
+#      - uses: actions/cache@v4
+#        with:
+#          path: .turbo
+#          key: '${{ runner.os }}-turbo-${{ github.sha }}'
+#          restore-keys: |
+#            ${{ runner.os }}-turbo-
+#
+#      - uses: actions/setup-node@v4
+#        with:
+#          node-version: 22
+#          cache: pnpm
+#
+#      - run: pnpm install --frozen-lockfile
+#
+#      - run: pnpm vercel deploy --token=${{ secrets.VERCEL_TOKEN }}
+#        env:
+#          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.github/workflows/destroy-preview.yml
+++ b/.github/workflows/destroy-preview.yml
@@ -1,0 +1,132 @@
+name: Destroy Preview Deployment
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+
+env:
+  CI: true
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+  TURBO_TEAM: ${{ secrets.VERCEL_ORG_ID }}
+  DOMAIN_NAME: ${{ secrets.DOMAIN_NAME }}
+  NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+  NEON_PROJECT: ${{ secrets.NEON_PROJECT }}
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  destroy-endpoints:
+    runs-on: ubuntu-latest
+    env:
+      STAGE: ${{ github.event.number || github.sha }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: '${{ runner.os }}-turbo-${{ github.sha }}'
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/atlas-deploy-role
+          aws-region: eu-west-1
+
+      - run: pnpm cdk:backend-api -- deploy --all --require-approval never
+
+      - run: pnpm cdk:frontend-api -- deploy --all --require-approval never
+
+  destroy-engine:
+    runs-on: ubuntu-latest
+    needs: [destroy-endpoints]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: '${{ runner.os }}-turbo-${{ github.sha }}'
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/atlas-deploy-role
+          aws-region: eu-west-1
+
+      - run: pnpm cdk:network -- deploy --all --require-approval never
+
+      - run: pnpm cdk:migrations -- deploy --all --require-approval never
+
+      - run: pnpm cdk:engine -- deploy --all --require-approval never
+
+#  destroy-app:
+#    runs-on: ubuntu-latest
+#    needs: [destroy-endpoints, destroy-engine]
+#    environment: preview
+#
+#    steps:
+#      - uses: actions/checkout@v4
+#
+#      - uses: pnpm/action-setup@v4
+#        with:
+#          run_install: false
+#
+#      - uses: actions/cache@v4
+#        with:
+#          path: .turbo
+#          key: '${{ runner.os }}-turbo-${{ github.sha }}'
+#          restore-keys: |
+#            ${{ runner.os }}-turbo-
+#
+#      - uses: actions/setup-node@v4
+#        with:
+#          node-version: 22
+#          cache: pnpm
+#
+#      - run: pnpm install --frozen-lockfile
+#
+#      - run: pnpm vercel deploy --token=${{ secrets.VERCEL_TOKEN }}
+#        env:
+#          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+  destroy-database-branch:
+    runs-on: ubuntu-latest
+    needs: [destroy-endpoints, destroy-engine]
+
+    steps:
+      - uses: neondatabase/delete-branch-action@v3
+        with:
+          project_id: ${{ secrets.NEON_PROJECT }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+          branch_name: ${{ github.event.number || github.sha }}

--- a/.github/workflows/destroy-preview.yml
+++ b/.github/workflows/destroy-preview.yml
@@ -13,6 +13,7 @@ env:
   DOMAIN_NAME: ${{ secrets.DOMAIN_NAME }}
   NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
   NEON_PROJECT: ${{ secrets.NEON_PROJECT }}
+  STAGE: ${{ github.event.number || github.sha }}
 
 on:
   pull_request:
@@ -21,8 +22,6 @@ on:
 jobs:
   destroy-endpoints:
     runs-on: ubuntu-latest
-    env:
-      STAGE: ${{ github.event.number || github.sha }}
 
     steps:
       - uses: actions/checkout@v4
@@ -50,9 +49,9 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/atlas-deploy-role
           aws-region: eu-west-1
 
-      - run: pnpm cdk:backend-api -- deploy --all --require-approval never
+      - run: pnpm cdk:backend-api -- deploy --all --require-approval never --context stage=${{ env.STAGE }}
 
-      - run: pnpm cdk:frontend-api -- deploy --all --require-approval never
+      - run: pnpm cdk:frontend-api -- deploy --all --require-approval never --context stage=${{ env.STAGE }}
 
   destroy-engine:
     runs-on: ubuntu-latest
@@ -84,11 +83,11 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/atlas-deploy-role
           aws-region: eu-west-1
 
-      - run: pnpm cdk:network -- deploy --all --require-approval never
+      - run: pnpm cdk:network -- deploy --all --require-approval never --context stage=${{ env.STAGE }}
 
-      - run: pnpm cdk:migrations -- deploy --all --require-approval never
+      - run: pnpm cdk:migrations -- deploy --all --require-approval never --context stage=${{ env.STAGE }}
 
-      - run: pnpm cdk:engine -- deploy --all --require-approval never
+      - run: pnpm cdk:engine -- deploy --all --require-approval never --context stage=${{ env.STAGE }}
 
 #  destroy-app:
 #    runs-on: ubuntu-latest

--- a/.github/workflows/destroy-preview.yml
+++ b/.github/workflows/destroy-preview.yml
@@ -13,7 +13,7 @@ env:
   DOMAIN_NAME: ${{ secrets.DOMAIN_NAME }}
   NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
   NEON_PROJECT: ${{ secrets.NEON_PROJECT }}
-  STAGE: ${{ github.event.number || github.sha }}
+  STAGE: ${{ github.event.number && 'pr-' || '' }}${{ github.event.number || github.sha }}
 
 on:
   pull_request:

--- a/.github/workflows/destroy-preview.yml
+++ b/.github/workflows/destroy-preview.yml
@@ -49,9 +49,7 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/atlas-deploy-role
           aws-region: eu-west-1
 
-      - run: pnpm cdk:backend-api -- deploy --all --require-approval never --context stage=${{ env.STAGE }}
-
-      - run: pnpm cdk:frontend-api -- deploy --all --require-approval never --context stage=${{ env.STAGE }}
+      - run: pnpm cdk:api -- destroy --all --require-approval never --force --context stage=${{ env.STAGE }}
 
   destroy-engine:
     runs-on: ubuntu-latest
@@ -83,11 +81,11 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/atlas-deploy-role
           aws-region: eu-west-1
 
-      - run: pnpm cdk:network -- deploy --all --require-approval never --context stage=${{ env.STAGE }}
+      - run: pnpm cdk:engine -- destroy --all --require-approval never --force --context stage=${{ env.STAGE }}
 
-      - run: pnpm cdk:migrations -- deploy --all --require-approval never --context stage=${{ env.STAGE }}
+      - run: pnpm cdk:migrations -- destroy --all --require-approval never --force --context stage=${{ env.STAGE }}
 
-      - run: pnpm cdk:engine -- deploy --all --require-approval never --context stage=${{ env.STAGE }}
+      - run: pnpm cdk:network -- destroy --all --require-approval never --force --context stage=${{ env.STAGE }}
 
 #  destroy-app:
 #    runs-on: ubuntu-latest
@@ -115,7 +113,7 @@ jobs:
 #
 #      - run: pnpm install --frozen-lockfile
 #
-#      - run: pnpm vercel deploy --token=${{ secrets.VERCEL_TOKEN }}
+#      - run: pnpm vercel destroy --token=${{ secrets.VERCEL_TOKEN }}
 #        env:
 #          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
@@ -124,6 +122,8 @@ jobs:
     needs: [destroy-endpoints, destroy-engine]
 
     steps:
+      - uses: actions/checkout@v4
+        
       - uses: neondatabase/delete-branch-action@v3
         with:
           project_id: ${{ secrets.NEON_PROJECT }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ cdk.out
 node_modules
 *.d.ts.map
 .vercel
+
+cdk.context.json

--- a/apps/app-e2e/playwright.config.ts
+++ b/apps/app-e2e/playwright.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig, devices } from '@playwright/test'
 import 'dotenv/config'
 
-const BASE_URL = process.env.BASE_URL || 'https://app.eu-west-1.atlas.erikvandam.dev'
+const BASE_URL =
+  process.env.BASE_URL || 'https://app.eu-west-1.atlas.erikvandam.dev'
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -33,7 +34,7 @@ export default defineConfig({
     trace: 'retry-with-trace',
     extraHTTPHeaders: {
       'x-vercel-protection-bypass': process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
-    }
+    },
   },
 
   /* Configure projects for major browsers */

--- a/apps/network/bin/app.ts
+++ b/apps/network/bin/app.ts
@@ -27,6 +27,7 @@ new RootNetwork(app, 'network', {
   projectName,
   stage,
   env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
     region: 'eu-west-1',
   },
   domainName,

--- a/apps/network/lib/network.ts
+++ b/apps/network/lib/network.ts
@@ -25,7 +25,11 @@ export class Network extends RegionStack {
 
     const rootHostedZone = this.getRootHostedZone(props)
 
-    const zoneName = `${props.env.region}.${props.domainName}`
+    let zoneName = `${props.env.region}.${props.domainName}`
+
+    if (props.stage !== 'prod') {
+      zoneName = `${props.env.region}.${props.stage}.envs.${props.domainName}`
+    }
 
     const delegatedZone = new PublicHostedZone(this, 'delegated-hosted-zone', {
       zoneName,

--- a/apps/network/lib/root-network.ts
+++ b/apps/network/lib/root-network.ts
@@ -19,8 +19,14 @@ export class RootNetwork extends RootStack<Network, NetworkProps> {
   constructor(scope: Construct, id: string, props: Props) {
     super(scope, id, props)
 
+    let zoneName = props.domainName
+
+    if (props.stage !== 'prod') {
+      zoneName = `${props.stage}.envs.${props.domainName}`
+    }
+
     const zone = new PublicHostedZone(this, 'root-public-zone', {
-      zoneName: props.domainName,
+      zoneName,
       comment: 'This is the root hosted zone for the project',
     })
 
@@ -56,10 +62,12 @@ export class RootNetwork extends RootStack<Network, NetworkProps> {
       zone,
     })
 
-    new ARecord(this, 'a', {
-      target: RecordTarget.fromIpAddresses('76.76.21.21'),
-      recordName: props.domainName,
-      zone,
-    })
+    if (props.stage === 'prod') {
+      new ARecord(this, 'a', {
+        target: RecordTarget.fromIpAddresses('76.76.21.21'),
+        recordName: props.domainName,
+        zone,
+      })
+    }
   }
 }

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -2,6 +2,6 @@
 
 ## Overview
 
-This project uses [Clerk](https://clerk.dev/) for authentication.
+This project uses [Clerk](https://clerk.dev) for authentication.
 Clerk provides a complete user management solution, including sign-up, sign-in,
 and user profile management.

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,6 @@
+# Database
+
+## Overview
+
+This project uses [Neon](https://neon.com) for database management and hosting.
+Neon provides a serverless Postgres database that is easy to set up and manage.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "build:app": "turbo build --filter=app",
     "build:website": "turbo build --filter=website",
     "cdk": "turbo cdk --parallel",
+    "cdk:api": "turbo cdk --filter=backend-api --filter=frontend-api",
     "cdk:backend-api": "turbo cdk --filter=backend-api",
     "cdk:engine": "turbo cdk --filter=engine",
     "cdk:frontend-api": "turbo cdk --filter=frontend-api",


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

# Proposed changes

<!-- Describe the changes here giving as much context as necessary -->

This pull request introduces automated preview deployment and teardown workflows, enhances environment-specific DNS management, and includes minor documentation and configuration updates. The main focus is on enabling isolated, per-PR preview environments with corresponding infrastructure and DNS setup, and ensuring proper cleanup when previews are destroyed.

**CI/CD Automation:**

* Added `.github/workflows/deploy-preview.yml` to automate building, testing, and deploying preview environments for pull requests, including provisioning infrastructure and database branches for each PR.
* Added `.github/workflows/destroy-preview.yml` to automatically destroy preview environments and associated resources when a pull request is closed, including teardown of database branches and infrastructure.

**Infrastructure & DNS Management:**

* Updated `apps/network/lib/root-network.ts` and `apps/network/lib/network.ts` to support environment-specific DNS zones and delegation, ensuring that non-production environments (like previews) get their own subdomains and NS records for proper isolation. [[1]](diffhunk://#diff-773d067e34a049c4c0352b7e8a1e5fbcb522f46af32bc1352d9854971aeecf6fR23-R54) [[2]](diffhunk://#diff-773d067e34a049c4c0352b7e8a1e5fbcb522f46af32bc1352d9854971aeecf6fR87-R95) [[3]](diffhunk://#diff-840de4e45cfa834f618aece1637db85407d960a4cd364f3eb33520cf0e60aa69L28-R32) [[4]](diffhunk://#diff-773d067e34a049c4c0352b7e8a1e5fbcb522f46af32bc1352d9854971aeecf6fR9)

## Related links

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [GitHub's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

- Related issue #
- Closes #22

## Definition of Done

<!-- Strikethrough any below that are not applicable. -->

**Always:**

- [x] All Acceptance Criteria have been met <!-- (if not, specify what's left via TODOs)  -->
- [x] Test successfully locally
- ~~[ ] Increase or maintain coverage~~
